### PR TITLE
auto add label of "fig:"

### DIFF
--- a/Overleaf-PasteImagesFromClipboard.user.js
+++ b/Overleaf-PasteImagesFromClipboard.user.js
@@ -110,6 +110,7 @@ document.querySelector('.ace_editor').addEventListener('paste', function(e){
                     _ide.editorManager.$scope.editor.sharejs_doc.ace.insert("\\begin{figure}[h!]\n\
 \t\\centering\n\
 \t\\includegraphics[width=0.66\\textwidth]{assets/" + hash + ".png}\n\
+\t\\label{fig:" + hash + "}\n\
 \t\\caption{Caption}\n\
 \\end{figure}"
                                                                            );


### PR DESCRIPTION
people may would like to copy the caption to the label, auto add label cmd will release that move to ctrl+c and ctrl+v

A better way is to set the cursor to both label and caption, I don't know how