### PR TITLE
added line label in the tempelate

### DIFF
--- a/Overleaf-PasteImagesFromClipboard.user.js
+++ b/Overleaf-PasteImagesFromClipboard.user.js
@@ -111,9 +111,10 @@ document.querySelector('.ace_editor').addEventListener('paste', function(e){
 \t\\centering\n\
 \t\\includegraphics[width=0.66\\textwidth]{assets/" + hash + ".png}\n\
 \t\\caption{Caption}\n\
+\t\\label{fig:_" + hash + "}\n\
 \\end{figure}"
                                                                            );
-                    _ide.editorManager.$scope.editor.sharejs_doc.ace.selection.moveCursorBy(-1,1);
+                    _ide.editorManager.$scope.editor.sharejs_doc.ace.selection.moveCursorBy(-2,1);
                     _ide.editorManager.$scope.editor.sharejs_doc.ace.selection.selectWordRight()
                 };
             }


### PR DESCRIPTION
Added `\label` by default so that would be more convenient.

the label will start with `fig:_` to split with the edited ` fig:` of my habit (i.e. unedited fig will with a label like "_hashhash") and even if I leave it there, will not make much trouble since `hash` is unlikely to conflict and will not show in auto fill list when I typed `fig: `

> note there is a  <space> in `fig: `